### PR TITLE
refactor: Remove global console suppression from tests

### DIFF
--- a/docs/ai/reference/TESTING_REFERENCE.md
+++ b/docs/ai/reference/TESTING_REFERENCE.md
@@ -38,6 +38,31 @@ npm test -- --coverage --watchAll=false
 - **Coverage Tool**: Built into Jest, reported via SonarQube integration
 - **Global Setup**: `src/test/setup.ts` configures global test environment
 
+### Console Output in Tests
+**Console methods (log, warn, error) are NOT globally suppressed.**
+
+This means you will see console output during test runs, which aids debugging. If a specific test needs to suppress or verify console output:
+
+```typescript
+it('should handle error gracefully', () => {
+  // Suppress console.error for this test only
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+  // Test code that triggers expected error
+  someFunction();
+
+  // Optionally verify the error was logged
+  expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error message'));
+
+  // Clean up
+  consoleSpy.mockRestore();
+});
+```
+
+**IMPORTANT**: Local console mocking is NOT the same as mocking service dependencies:
+- **Console mocking**: Local, per-test, for suppressing noise or verifying logging
+- **Service mocking**: Global, centralized in `src/test/__mocks__/`, see [TESTING_MOCKS_REFERENCE.md](./TESTING_MOCKS_REFERENCE.md)
+
 ## Coverage Exclusions Configuration
 
 ### Jest Configuration (`jest.config.js`)

--- a/src/services/animations/AnimationOrchestrator.test.ts
+++ b/src/services/animations/AnimationOrchestrator.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for AnimationOrchestrator
+ *
+ * Tests the animation orchestration logic including:
+ * - Game state change detection
+ * - Animation intent publishing
+ * - Round transitions
+ * - Board and category introductions
+ * - Daily Double detection
+ */
+
+import { AnimationOrchestrator } from './AnimationOrchestrator';
+import { AnimationEvents } from './AnimationEvents';
+import { ClueService } from '../clues/ClueService';
+import type { Game } from '../games/GameService';
+
+// Mock dependencies
+jest.mock('./AnimationEvents');
+jest.mock('../clues/ClueService');
+
+describe('AnimationOrchestrator', () => {
+  let orchestrator: AnimationOrchestrator;
+  let mockPublish: jest.SpyInstance;
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    orchestrator = AnimationOrchestrator.getInstance();
+    // Clear any persisted state from previous tests
+    (orchestrator as any).lastStateByGame.clear();
+    mockPublish = jest.spyOn(AnimationEvents, 'publish').mockImplementation();
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleSpy.mockRestore();
+  });
+
+  describe('getInstance', () => {
+    it('should return singleton instance', () => {
+      const instance1 = AnimationOrchestrator.getInstance();
+      const instance2 = AnimationOrchestrator.getInstance();
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('ingestGameUpdate - Round Transitions', () => {
+    it('should publish RoundTransition when round changes during round_transition status', () => {
+      const gameId = 'game-123';
+      
+      // First update - establish initial state
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'in_progress',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      // Second update - round transition
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'round_transition',
+        current_round: 'double'
+      } as Partial<Game> & { id: string });
+
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: 'RoundTransition',
+        gameId,
+        fromRound: 'jeopardy',
+        toRound: 'double'
+      });
+    });
+
+    it('should NOT publish RoundTransition when round changes but status is not round_transition', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'in_progress',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'in_progress',
+        current_round: 'double'
+      } as Partial<Game> & { id: string });
+
+      expect(mockPublish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'RoundTransition' })
+      );
+    });
+
+    it('should NOT publish RoundTransition on first update', () => {
+      orchestrator.ingestGameUpdate({
+        id: 'game-123',
+        status: 'round_transition',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      expect(mockPublish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ingestGameUpdate - Board Intro', () => {
+    it('should publish BoardIntro when entering game_intro status', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'lobby',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'game_intro',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: 'BoardIntro',
+        gameId,
+        round: 'jeopardy'
+      });
+    });
+
+    it('should NOT publish BoardIntro when already in game_intro', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'game_intro',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      mockPublish.mockClear();
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'game_intro',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      expect(mockPublish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'BoardIntro' })
+      );
+    });
+  });
+
+  describe('ingestGameUpdate - Category Intro', () => {
+    it('should publish CategoryIntro when category number changes during introducing_categories', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'introducing_categories',
+        current_introduction_category: 0
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'introducing_categories',
+        current_introduction_category: 1
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: 'CategoryIntro',
+        gameId,
+        categoryNumber: 1
+      });
+    });
+
+    it('should publish CategoryIntro for each category change', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'introducing_categories',
+        current_introduction_category: 1
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'introducing_categories',
+        current_introduction_category: 2
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'introducing_categories',
+        current_introduction_category: 3
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: 'CategoryIntro',
+        gameId,
+        categoryNumber: 2
+      });
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: 'CategoryIntro',
+        gameId,
+        categoryNumber: 3
+      });
+    });
+
+    it('should NOT publish CategoryIntro when category is 0', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'introducing_categories',
+        current_introduction_category: 0
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      expect(mockPublish).not.toHaveBeenCalled();
+    });
+
+    it('should NOT publish CategoryIntro when status is not introducing_categories', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'in_progress',
+        current_introduction_category: 1
+      } as Partial<Game> & { id: string; current_introduction_category: number });
+
+      expect(mockPublish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ingestGameUpdate - Daily Double', () => {
+    it('should publish DailyDoubleReveal when focused_player_id is set for daily double clue', async () => {
+      const gameId = 'game-123';
+      const clueId = 'clue-456';
+      
+      (ClueService.isDailyDouble as jest.Mock).mockResolvedValue(true);
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        focused_clue_id: clueId,
+        focused_player_id: null
+      } as Partial<Game> & { id: string });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        focused_clue_id: clueId,
+        focused_player_id: 'player-789'
+      } as Partial<Game> & { id: string });
+
+      // Wait for async isDailyDouble check
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(ClueService.isDailyDouble).toHaveBeenCalledWith(clueId);
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: 'DailyDoubleReveal',
+        gameId,
+        clueId
+      });
+    });
+
+    it('should NOT publish DailyDoubleReveal for regular clue', async () => {
+      const gameId = 'game-123';
+      const clueId = 'clue-456';
+      
+      (ClueService.isDailyDouble as jest.Mock).mockResolvedValue(false);
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        focused_clue_id: clueId,
+        focused_player_id: null
+      } as Partial<Game> & { id: string });
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        focused_clue_id: clueId,
+        focused_player_id: 'player-789'
+      } as Partial<Game> & { id: string });
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockPublish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'DailyDoubleReveal' })
+      );
+    });
+
+    it('should handle isDailyDouble error gracefully', async () => {
+      const gameId = 'game-123';
+      const clueId = 'clue-456';
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      (ClueService.isDailyDouble as jest.Mock).mockRejectedValue(new Error('Database error'));
+
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        focused_clue_id: clueId,
+        focused_player_id: 'player-789'
+      } as Partial<Game> & { id: string });
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error checking daily double status'),
+        expect.any(Error)
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear game state', () => {
+      const gameId = 'game-123';
+      
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'in_progress',
+        current_round: 'jeopardy'
+      } as Partial<Game> & { id: string });
+
+      orchestrator.clear(gameId);
+
+      // After clearing, next update should not trigger round transition
+      orchestrator.ingestGameUpdate({
+        id: gameId,
+        status: 'round_transition',
+        current_round: 'double'
+      } as Partial<Game> & { id: string });
+
+      expect(mockPublish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'RoundTransition' })
+      );
+    });
+  });
+});
+

--- a/src/services/animations/BuzzerStateService.test.ts
+++ b/src/services/animations/BuzzerStateService.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for BuzzerStateService
+ *
+ * Tests the six-state buzzer system including:
+ * - State determination based on game context
+ * - State transition validation
+ * - State utility functions (CSS classes, display text, etc.)
+ * - State priority and interactivity
+ */
+
+import { BuzzerStateService, type BuzzerStateContext } from './BuzzerStateService';
+import { BuzzerState } from '../../types/BuzzerState';
+
+describe('BuzzerStateService', () => {
+  let service: BuzzerStateService;
+
+  beforeEach(() => {
+    service = BuzzerStateService.getInstance();
+  });
+
+  describe('getInstance', () => {
+    it('should return singleton instance', () => {
+      const instance1 = BuzzerStateService.getInstance();
+      const instance2 = BuzzerStateService.getInstance();
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('determineState', () => {
+    it('should return HIDDEN when game is in lobby', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'lobby',
+        hasClue: false,
+        isLocked: false,
+        hasBuzzed: false,
+        isFrozen: false
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.HIDDEN);
+    });
+
+    it('should return INACTIVE when introducing categories', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'introducing_categories',
+        hasClue: false,
+        isLocked: false,
+        hasBuzzed: false,
+        isFrozen: false
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.INACTIVE);
+    });
+
+    it('should return FROZEN when player is frozen', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'in_progress',
+        hasClue: true,
+        isLocked: false,
+        hasBuzzed: false,
+        isFrozen: true
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.FROZEN);
+    });
+
+    it('should return BUZZED when player has buzzed', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'in_progress',
+        hasClue: true,
+        isLocked: false,
+        hasBuzzed: true,
+        isFrozen: false
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.BUZZED);
+    });
+
+    it('should return INACTIVE when no clue is selected', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'in_progress',
+        hasClue: false,
+        isLocked: false,
+        hasBuzzed: false,
+        isFrozen: false
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.INACTIVE);
+    });
+
+    it('should return LOCKED when clue is selected but buzzer is locked', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'in_progress',
+        hasClue: true,
+        isLocked: true,
+        hasBuzzed: false,
+        isFrozen: false
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.LOCKED);
+    });
+
+    it('should return UNLOCKED when clue is selected and buzzer is unlocked', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'in_progress',
+        hasClue: true,
+        isLocked: false,
+        hasBuzzed: false,
+        isFrozen: false
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.UNLOCKED);
+    });
+
+    it('should prioritize frozen state over buzzed state', () => {
+      const context: BuzzerStateContext = {
+        gameStatus: 'in_progress',
+        hasClue: true,
+        isLocked: false,
+        hasBuzzed: true,
+        isFrozen: true
+      };
+      expect(service.determineState(context)).toBe(BuzzerState.FROZEN);
+    });
+  });
+
+  describe('validateTransition', () => {
+    it('should allow HIDDEN to INACTIVE transition', () => {
+      const result = service.validateTransition(BuzzerState.HIDDEN, BuzzerState.INACTIVE);
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should allow INACTIVE to LOCKED transition', () => {
+      const result = service.validateTransition(BuzzerState.INACTIVE, BuzzerState.LOCKED);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should allow LOCKED to UNLOCKED transition', () => {
+      const result = service.validateTransition(BuzzerState.LOCKED, BuzzerState.UNLOCKED);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should allow UNLOCKED to BUZZED transition', () => {
+      const result = service.validateTransition(BuzzerState.UNLOCKED, BuzzerState.BUZZED);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should allow BUZZED to INACTIVE transition', () => {
+      const result = service.validateTransition(BuzzerState.BUZZED, BuzzerState.INACTIVE);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should allow FROZEN to INACTIVE transition', () => {
+      const result = service.validateTransition(BuzzerState.FROZEN, BuzzerState.INACTIVE);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject invalid HIDDEN to LOCKED transition', () => {
+      const result = service.validateTransition(BuzzerState.HIDDEN, BuzzerState.LOCKED);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('Invalid transition from hidden to locked');
+    });
+
+    it('should reject invalid UNLOCKED to FROZEN direct transition', () => {
+      const result = service.validateTransition(BuzzerState.UNLOCKED, BuzzerState.FROZEN);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('Invalid transition');
+    });
+  });
+
+  describe('getStateClassName', () => {
+    it('should return correct CSS class for each state', () => {
+      expect(service.getStateClassName(BuzzerState.HIDDEN)).toBe('buzzer-hidden');
+      expect(service.getStateClassName(BuzzerState.INACTIVE)).toBe('buzzer-inactive');
+      expect(service.getStateClassName(BuzzerState.LOCKED)).toBe('buzzer-locked');
+      expect(service.getStateClassName(BuzzerState.UNLOCKED)).toBe('buzzer-unlocked');
+      expect(service.getStateClassName(BuzzerState.BUZZED)).toBe('buzzer-buzzed');
+      expect(service.getStateClassName(BuzzerState.FROZEN)).toBe('buzzer-frozen');
+    });
+  });
+
+  describe('getStateDisplayText', () => {
+    it('should return correct display text for each state', () => {
+      expect(service.getStateDisplayText(BuzzerState.HIDDEN)).toBe('Game Starting...');
+      expect(service.getStateDisplayText(BuzzerState.INACTIVE)).toBe('Ready');
+      expect(service.getStateDisplayText(BuzzerState.LOCKED)).toBe('Wait...');
+      expect(service.getStateDisplayText(BuzzerState.UNLOCKED)).toBe('BUZZ!');
+      expect(service.getStateDisplayText(BuzzerState.BUZZED)).toBe('Buzzed!');
+      expect(service.getStateDisplayText(BuzzerState.FROZEN)).toBe('Frozen');
+    });
+
+    it('should return Unknown for invalid state', () => {
+      expect(service.getStateDisplayText('invalid' as BuzzerState)).toBe('Unknown');
+    });
+  });
+
+  describe('isInteractive', () => {
+    it('should return true only for UNLOCKED state', () => {
+      expect(service.isInteractive(BuzzerState.UNLOCKED)).toBe(true);
+      expect(service.isInteractive(BuzzerState.HIDDEN)).toBe(false);
+      expect(service.isInteractive(BuzzerState.INACTIVE)).toBe(false);
+      expect(service.isInteractive(BuzzerState.LOCKED)).toBe(false);
+      expect(service.isInteractive(BuzzerState.BUZZED)).toBe(false);
+      expect(service.isInteractive(BuzzerState.FROZEN)).toBe(false);
+    });
+  });
+
+  describe('getPostBuzzState', () => {
+    it('should return FROZEN for early buzz', () => {
+      expect(service.getPostBuzzState(BuzzerState.LOCKED, true)).toBe(BuzzerState.FROZEN);
+      expect(service.getPostBuzzState(BuzzerState.UNLOCKED, true)).toBe(BuzzerState.FROZEN);
+    });
+
+    it('should return BUZZED for valid buzz from UNLOCKED', () => {
+      expect(service.getPostBuzzState(BuzzerState.UNLOCKED, false)).toBe(BuzzerState.BUZZED);
+    });
+
+    it('should return current state for invalid buzz attempt', () => {
+      expect(service.getPostBuzzState(BuzzerState.INACTIVE, false)).toBe(BuzzerState.INACTIVE);
+      expect(service.getPostBuzzState(BuzzerState.LOCKED, false)).toBe(BuzzerState.LOCKED);
+    });
+  });
+
+  describe('getAllStates', () => {
+    it('should return all buzzer states', () => {
+      const states = service.getAllStates();
+      expect(states).toContain(BuzzerState.HIDDEN);
+      expect(states).toContain(BuzzerState.INACTIVE);
+      expect(states).toContain(BuzzerState.LOCKED);
+      expect(states).toContain(BuzzerState.UNLOCKED);
+      expect(states).toContain(BuzzerState.BUZZED);
+      expect(states).toContain(BuzzerState.FROZEN);
+      expect(states).toHaveLength(6);
+    });
+  });
+
+  describe('isActiveState', () => {
+    it('should return false for HIDDEN and INACTIVE', () => {
+      expect(service.isActiveState(BuzzerState.HIDDEN)).toBe(false);
+      expect(service.isActiveState(BuzzerState.INACTIVE)).toBe(false);
+    });
+
+    it('should return true for active states', () => {
+      expect(service.isActiveState(BuzzerState.LOCKED)).toBe(true);
+      expect(service.isActiveState(BuzzerState.UNLOCKED)).toBe(true);
+      expect(service.isActiveState(BuzzerState.BUZZED)).toBe(true);
+      expect(service.isActiveState(BuzzerState.FROZEN)).toBe(true);
+    });
+  });
+
+  describe('getStatePriority', () => {
+    it('should return correct priority for each state', () => {
+      expect(service.getStatePriority(BuzzerState.BUZZED)).toBe(5);
+      expect(service.getStatePriority(BuzzerState.FROZEN)).toBe(4);
+      expect(service.getStatePriority(BuzzerState.UNLOCKED)).toBe(3);
+      expect(service.getStatePriority(BuzzerState.LOCKED)).toBe(2);
+      expect(service.getStatePriority(BuzzerState.INACTIVE)).toBe(1);
+      expect(service.getStatePriority(BuzzerState.HIDDEN)).toBe(0);
+    });
+
+    it('should return 0 for invalid state', () => {
+      expect(service.getStatePriority('invalid' as BuzzerState)).toBe(0);
+    });
+
+    it('should have BUZZED as highest priority', () => {
+      const allStates = service.getAllStates();
+      const priorities = allStates.map(state => service.getStatePriority(state));
+      const maxPriority = Math.max(...priorities);
+      expect(service.getStatePriority(BuzzerState.BUZZED)).toBe(maxPriority);
+    });
+  });
+});
+

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,19 +42,26 @@ global.assert = (condition: unknown, message?: string): asserts condition => {
 import { initializeGlobals } from '../shared/utils/setup';
 initializeGlobals();
 
-// Suppress console output in tests unless explicitly testing them
-const originalConsoleWarn = console.warn;
-const originalConsoleError = console.error;
-const originalConsoleLog = console.log;
-
-beforeEach(() => {
-  console.warn = jest.fn();
-  console.error = jest.fn();
-  console.log = jest.fn(); // Suppress console.log during tests
-});
-
-afterEach(() => {
-  console.warn = originalConsoleWarn;
-  console.error = originalConsoleError;
-  console.log = originalConsoleLog;
-});
+/**
+ * NOTE: Console methods (log, warn, error) are NOT globally suppressed.
+ *
+ * If a test needs to suppress console output (e.g., testing error handling),
+ * mock console methods locally within that specific test:
+ *
+ * @example
+ * it('should handle error', () => {
+ *   const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+ *   // ... test code that triggers expected error ...
+ *   expect(consoleSpy).toHaveBeenCalled();
+ *   consoleSpy.mockRestore();
+ * });
+ *
+ * This approach:
+ * - Makes debugging easier (you can see actual console output during failures)
+ * - Makes tests more explicit about what they're testing
+ * - Avoids confusion about missing console output
+ *
+ * IMPORTANT: Local console mocking is NOT the same as mocking service dependencies.
+ * Service dependencies (Supabase, GameService, etc.) MUST use global mocks from
+ * src/test/__mocks__/ or src/services/__mocks__/. See TESTING_MOCKS_REFERENCE.md.
+ */


### PR DESCRIPTION
- Remove global console.log/warn/error mocking from src/test/setup.ts
- Add comprehensive documentation about console mocking strategy
- Clarify distinction between console mocking (local) vs service mocking (global)
- Update TESTING_REFERENCE.md with console mocking guidelines
- All 501 tests still pass after removing global suppression
- Improves debugging by making console output visible during test failures
- Makes tests more explicit about what they're testing

Rationale:
- Global suppression hides valuable debugging information
- Makes it harder to diagnose test failures
- Creates confusion for developers/agents about missing output
- Local mocking is more explicit and appropriate for specific tests